### PR TITLE
fix: use client-id instead of deprecated app-id for GitHub App token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Parse publish request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ This repo uses [getsentry/craft](https://github.com/getsentry/craft) for automat
 
 ### Prerequisites for releasing
 - GitHub App with `contents: write` and `issues: write` permissions
-  - Repo variable `APP_ID` and secret `APP_PRIVATE_KEY`
+  - Repo variable `APP_CLIENT_ID` and secret `APP_PRIVATE_KEY`
 - GitHub environment `production` on the repo
 - npm OIDC provenance linked for the `fossilize` package
 


### PR DESCRIPTION
The `app-id` input on `actions/create-github-app-token@v3` is deprecated in favor of `client-id`. This change:

- Renames `app-id` to `client-id` in both `release.yml` and `publish.yml`
- Updates the variable reference from `vars.APP_ID` to `vars.APP_CLIENT_ID`

**Action required**: Rename the repo variable from `APP_ID` to `APP_CLIENT_ID` in Settings → Secrets and variables → Actions → Variables (ensure the value is the app's Client ID, not the numeric App ID).