### PR TITLE
feat: strip debug symbols from Node binaries before SEA injection

### DIFF
--- a/src/impl.ts
+++ b/src/impl.ts
@@ -234,6 +234,22 @@ export default async function (
       flags.noCache ? null : flags.cacheDir,
       path.join(flags.outDir, outputName)
     );
+    // Strip debug symbols before SEA injection. Node.js ships with full
+    // symbol tables (~17 MiB on linux-x64). Must strip BEFORE postject
+    // injection — postject corrupts the ELF section-to-segment layout.
+    // Windows PE binaries don't ship debug symbols in release builds.
+    if (!platform.startsWith("win")) {
+      try {
+        const stripCmd = platform.startsWith("darwin")
+          ? ["strip", "-x", fossilizedBinary]
+          : ["strip", "--strip-unneeded", fossilizedBinary];
+        await run(stripCmd[0]!, ...stripCmd.slice(1));
+      } catch {
+        // Non-fatal: may fail when cross-stripping (e.g., macOS Mach-O on Linux)
+        console.warn(`  Warning: strip failed for ${platform} (non-fatal)`);
+      }
+    }
+
     // Use the code-cache blob for the host platform, base blob for others
     const blobForPlatform = (hasCodeCacheBlob && platform === currentPlatform)
       ? codeCacheBlobPath


### PR DESCRIPTION
## Summary

Strip debug symbols from Node binaries before postject SEA injection. Node.js ships with full symbol tables (~17 MiB on linux-x64) that aren't needed at runtime.

### Why before injection?

`strip` must run BEFORE postject injection. Postject corrupts the ELF section-to-segment layout, causing `strip` to fail with:
```
strip: section .text can't be allocated in segment 2
```

### Pipeline

```
download → copy (+ unsign on macOS/Win) → strip → inject SEA blob → sign
```

### Per-platform behavior

| Platform | Strip command | Savings | Notes |
|----------|-------------|---------|-------|
| Linux | `strip --strip-unneeded` | **~17 MiB** | Removes symbols + debug sections |
| macOS | `strip -x` | ~5-10 MiB | Local symbols; binary already unsigned by `macho-unsign` |
| Windows | skipped | 0 | PE releases don't ship debug symbols |
| Cross-compile | silently skipped | 0 | `strip` can't process foreign binary formats |

### Results (linux-x64, Sentry CLI)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Raw binary | 125 MiB | 108 MiB | **-14%** |
| Compressed | 34 MiB | 30 MiB | **-12%** |
| Startup | unchanged | unchanged | — |