### PR TITLE
feat: add --hole-punch flag to zero unused ICU data before signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 0.8.0
+
+### New Features ✨
+
+- Add `--hole-punch` flag to zero unused ICU data before signing, reducing compressed binary size by ~24%. Uses [binpunch](https://github.com/BYK/binpunch) internally. Opt-in via `--hole-punch` or `FOSSILIZE_HOLE_PUNCH=y` — drops non-English i18n data, so only enable for English-only CLIs.
+
 ## 0.7.0
 
 ### New Features ✨

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "fossilize",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fossilize",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "license": "MIT",
             "dependencies": {
                 "@stricli/auto-complete": "^1.1.0",
                 "@stricli/core": "^1.1.0",
+                "binpunch": "^1.0.0",
                 "esbuild": "^0.25.0",
                 "macho-unsign": "^2.0.6",
                 "p-limit": "^6.2.0",
@@ -691,6 +692,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/binpunch": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/binpunch/-/binpunch-1.0.0.tgz",
+            "integrity": "sha512-ghxdoerLN3WN64kteDJuL4d9dy7gbvcqoADNRWBk6aQ5FrYH1EmPmREAdcdIdTNAA3uW3V38Env5OqH2lj+i+g==",
+            "license": "MIT",
+            "bin": {
+                "binpunch": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "repository": "github:BYK/fossilize",
     "license": "MIT",
     "type": "module",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "keywords": [
         "node",
         "sea",
@@ -51,6 +51,7 @@
     "dependencies": {
         "@stricli/auto-complete": "^1.1.0",
         "@stricli/core": "^1.1.0",
+        "binpunch": "^1.0.0",
         "esbuild": "^0.25.0",
         "macho-unsign": "^2.0.6",
         "p-limit": "^6.2.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -78,6 +78,13 @@ const command = buildCommand({
         optional: false,
         default: envToBool(process.env["FOSSILIZE_SIGN"]),
       },
+      holePunch: {
+        kind: "boolean",
+        brief:
+          "Zero unused non-English ICU data before signing (smaller download; drops non-English i18n)",
+        optional: false,
+        default: envToBool(process.env["FOSSILIZE_HOLE_PUNCH"]),
+      },
       concurrencyLimit: {
         kind: "parsed",
         parse: Number,

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -20,6 +20,7 @@ interface CommandFlags {
   readonly noCache?: boolean;
   readonly noBundle: boolean;
   readonly sign: boolean;
+  readonly holePunch: boolean;
   readonly concurrencyLimit: number;
 }
 
@@ -271,6 +272,20 @@ export default async function (
     );
     console.log("Created executable", fossilizedBinary);
     fs.chmod(fossilizedBinary, 0o755);
+
+    // Hole-punch unused ICU data before signing so the signature covers the
+    // final bytes. Must run after SEA injection (ICU blob lives in the Node
+    // binary's .rodata, unaffected by postject) and before sign + notarize.
+    if (flags.holePunch) {
+      const { processBinary } = await import("binpunch");
+      const stats = processBinary(fossilizedBinary);
+      if (stats && stats.removedEntries > 0) {
+        console.log(
+          `Hole-punched ${stats.removedEntries}/${stats.totalEntries} ICU entries in ${fossilizedBinary}`
+        );
+      }
+    }
+
     if (!flags.sign) {
       console.log("Skipping signing, add `--sign` to sign the binary");
       if (platform.startsWith("darwin")) {


### PR DESCRIPTION
## Summary

Add a `--hole-punch` flag (env: `FOSSILIZE_HOLE_PUNCH=y`) that zeros unused ICU data entries in the SEA binary **before** code signing. This reduces compressed download size by ~24% while keeping the code signature valid.

Uses [binpunch](https://github.com/BYK/binpunch) internally — added as a dependency.

## Motivation

Fixes [getsentry/cli#1033](https://github.com/getsentry/cli/issues/1033): the Sentry CLI was running binpunch **after** fossilize signed the binary, invalidating the macOS code signature and causing AMFI SIGKILL on downloaded binaries. By integrating hole-punch into fossilize's pipeline (between `chmod` and `sign+notarize`), the signature always covers the final bytes.

## Pipeline order

```
download → unsign → strip → inject SEA → chmod → HOLE-PUNCH (new) → sign + notarize
```

## Design decisions

- **Opt-in, not default-on**: hole-punch drops non-English ICU data (`.cnv` charset converters, CJK break dictionaries, non-English locale data in collation/timezone/currency/etc). This is safe for English-only CLIs but would silently break `Intl.Collator('de')`, `Intl.Segmenter` CJK word mode, localized timezone/currency formatting, etc. for apps that need them.
- **Dependency, not vendored**: binpunch is a standalone package with a clean API (`processBinary(filePath)`). Adding it as a dep avoids duplicating ~250 lines of ICU parsing logic and ensures a single source of truth.
- **Dynamic import**: `await import('binpunch')` keeps binpunch out of the hot path when the flag is off.

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- End-to-end validation will happen in the downstream [getsentry/cli PR](https://github.com/getsentry/cli/issues/1033) which adds a CI signature verification gate (`rcodesign verify` + quarantine-and-execute)