### PR TITLE
chore: revert version to 0.7.0 for Craft release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fossilize",
-    "version": "0.8.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fossilize",
-            "version": "0.8.0",
+            "version": "0.7.0",
             "license": "MIT",
             "dependencies": {
                 "@stricli/auto-complete": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "repository": "github:BYK/fossilize",
     "license": "MIT",
     "type": "module",
-    "version": "0.8.0",
+    "version": "0.7.0",
     "keywords": [
         "node",
         "sea",


### PR DESCRIPTION
Craft expects to bump the version itself during the release workflow. Pre-bumping to 0.8.0 in the feat PR caused `npm version 0.8.0 --allow-same-version` to produce no diff → "Nothing to commit" error. This reverts to 0.7.0 so Craft can bump it to 0.8.0 and create the release commit.