### PR TITLE
fix: make strip failure non-fatal for cross-compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 0.8.1
+
+### Bug Fixes 🐛
+
+- Fix cross-compilation crash: `strip` failure on foreign architectures (e.g., ARM64 binary on x86_64 host) now correctly falls through as non-fatal instead of calling `process.exit()`
+
 ## 0.8.0
 
 ### New Features ✨

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -241,10 +241,15 @@ export default async function (
     // Windows PE binaries don't ship debug symbols in release builds.
     if (!platform.startsWith("win")) {
       try {
-        const stripCmd = platform.startsWith("darwin")
-          ? ["strip", "-x", fossilizedBinary]
-          : ["strip", "--strip-unneeded", fossilizedBinary];
-        await run(stripCmd[0]!, ...stripCmd.slice(1));
+        const stripArgs = platform.startsWith("darwin")
+          ? ["-x", fossilizedBinary]
+          : ["--strip-unneeded", fossilizedBinary];
+        // Use execFileAsync directly instead of run() — run() calls
+        // process.exit() on numeric error codes, bypassing try/catch.
+        // Cross-stripping (e.g., ARM64 binary on x86_64 host) legitimately
+        // fails and must be non-fatal.
+        await execFileAsync("strip", stripArgs, { encoding: "utf8" });
+        console.log(`> strip ${stripArgs.join(" ")}`);
       } catch {
         // Non-fatal: may fail when cross-stripping (e.g., macOS Mach-O on Linux)
         console.warn(`  Warning: strip failed for ${platform} (non-fatal)`);


### PR DESCRIPTION
## Problem

Cross-compiling (e.g., linux-arm64 on x86_64 host) crashes fossilize because `strip` fails with exit code 1 ("Unable to recognise the format of the input file") and the `run()` helper calls `process.exit(1)` for numeric error codes — bypassing the try/catch that was supposed to make it non-fatal.

## Root cause

`run()` (line 44) has two failure paths:
- Numeric exit code → `process.exit(code)` (**kills the process**, uncatchable)
- Non-numeric error → `throw new Error(...)` (caught by try/catch)

`strip` returns exit code 1, so `process.exit(1)` fires. The catch block on line 248 (`"Warning: strip failed... (non-fatal)"`) never executes.

## Fix

Replace `run()` with `execFileAsync` directly for the strip call. The error is now properly caught, a warning is printed, and fossilize continues with an unstripped binary.

This was always the intended behavior (the comment says "Non-fatal: may fail when cross-stripping") — it just never worked because of the `process.exit()` escape hatch in `run()`.