### PR TITLE
feat: add programmatic API export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,13 +74,13 @@ jobs:
 
       - name: Smoke test
         run: |
-            node dist/cli.js
+            node dist/bin/cli.js
 
       - name: Test with asset
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
             cd test
-            node ../dist/cli.js -a asset.txt --no-bundle sample.cjs
+            node ../dist/bin/cli.js -a asset.txt --no-bundle sample.cjs
             expected=$(cat asset.txt)
             actual=$(./dist-bin/sample-linux-x64)
             [ "$actual" = "$expected" ]

--- a/.lore.md
+++ b/.lore.md
@@ -1,0 +1,25 @@
+<!-- Managed by lore (https://github.com/BYK/loreai) — manual edits are imported on next session. -->
+
+## Long-term Knowledge
+
+### Gotcha
+
+<!-- lore:019e51d2-db62-77a1-ac51-2d3227c3ecac -->
+* **Craft auto-version picks current package.json version — re-run with explicit version if already published**: Trap: Craft's \`version: auto\` reads package.json and detects no new conventional commits → creates a publish issue for the version already on npm (e.g. 0.5.0 when 0.5.0 is already published). Looks like it should bump, but it doesn't if package.json already matches latest npm. Fix: close the stale publish issue, then re-trigger the release workflow with an explicit version string (e.g. \`0.6.0\`). Craft will then create the correct release branch and publish issue.
+
+### Preference
+
+<!-- lore:019e515b-7395-765e-a9cb-2c29f80c74ae -->
+* **Always explore reference repos thoroughly before implementing Craft-based publishing**: When setting up Craft-based publishing for a repo, the user consistently requests full exploration of both the target repo AND existing reference repos (superset, loreai/opencode-lore) that already have Craft configured. This includes reading complete file contents of .craft.yml, all .github/workflows/\*.yml files, package.json, and project structure. The user wants to understand the established pattern before implementing it in a new repo, treating superset and opencode-lore as canonical templates. Always read the full contents of workflow files (not just summaries) from reference repos when setting up Craft publishing.
+
+<!-- lore:019e51c6-8045-7e69-8ed7-1afc33f17f45 -->
+* **Always reset package.json version to latest published npm version before letting Craft manage versioning**: When setting up or fixing Craft-based publishing, reset package.json version to the latest version actually published on npm (not whatever is in the repo), then let Craft auto-determine the next version. Check \`npm view \<pkg> version\` for the true latest. If Craft auto-versions to the already-published version (because package.json matches and no new conventional commits detected), re-run the release workflow with an explicit version (e.g. \`0.6.0\`). Sync lockfiles after version change (\`npm install\` or \`pnpm install\`), then commit and trigger Craft.
+
+<!-- lore:019e51c5-9507-77ce-a7d4-27593693d3ae -->
+* **Always use Craft for automated release/publish workflows in personal projects**: When the user wants to release a package (e.g., fossilize), they consistently reach for Sentry's Craft tool rather than manual npm publish, semantic-release, or other alternatives. This applies even for personal/open-source projects. The pattern includes: setting up \`.craft.yml\` with npm OIDC + GitHub Release targets, adding \`release.yml\` (workflow\_dispatch → craft prepare) and \`publish.yml\` (issue label → craft publish) GitHub Actions workflows, and modifying build workflows to upload artifacts. When something goes wrong with a release (wrong version, skipped version, bad commit), the user wants to fix the git state and re-trigger Craft rather than publish manually.
+
+<!-- lore:019e51d2-db4a-753a-b96f-f94fe513b794 -->
+* **Always use pnpm add -D — all packages go in devDependencies**: In getsentry/cli, ALL packages must be in \`devDependencies\`, never \`dependencies\`. Everything is bundled at build time via esbuild. Always use \`pnpm add -D \<package>\` (the \`-D\` flag). CI enforces this with \`pnpm run check:deps\`. This is an absolute directive from AGENTS.md.
+
+<!-- lore:019e51c7-69d5-7ada-895d-d23f21935fd0 -->
+* **Always verify workflow run results and identify the next manual step after triggering CI/CD**: After triggering a GitHub Actions workflow (release, build, publish), check all job statuses to confirm success, then identify the specific next manual action. For Craft-based releases: find the publish issue URL from workflow logs, verify CI passes on the \`release/X.Y.Z\` branch, then add the \`accepted\` label to trigger npm publish. Track each job individually. The workflow run is a checkpoint — always ask 'what do I need to do next?' Also watch for deprecation warnings (e.g. \`app-id\` → \`client-id\` in \`actions/create-github-app-token@v3\`) and fix them in follow-up PRs.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,28 @@ and then add a `compile` script to your project referencing fossilize:
 }
 ```
 
+### Programmatic API
+
+You can also use fossilize as a library in your build scripts:
+
+```ts
+import { fossilize } from "fossilize";
+
+await fossilize(
+  {
+    nodeVersion: "lts",
+    platforms: ["darwin-arm64", "linux-x64", "win-x64"],
+    outDir: "./dist-bin",
+    cacheDir: ".node-cache",
+    noBundle: false,
+    sign: false,
+    holePunch: false,
+    concurrencyLimit: 3,
+  },
+  "./src/main.ts",
+);
+```
+
 ### Supported Environment Variables
 
 - `FOSSILIZE_SIGN`

--- a/package.json
+++ b/package.json
@@ -20,10 +20,17 @@
         "import-meta-url.js",
         "entitlements.plist"
     ],
-    "main": "dist/cli.js",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts"
+        }
+    },
     "bin": {
-        "fossilize": "dist/cli.js",
-        "__fossilize_bash_complete": "dist/bash-complete.js"
+        "fossilize": "dist/bin/cli.js",
+        "__fossilize_bash_complete": "dist/bin/bash-complete.js"
     },
     "engines": {
         "node": ">=18"
@@ -36,6 +43,7 @@
     },
     "tsup": {
         "entry": [
+            "src/index.ts",
             "src/bin/cli.ts",
             "src/bin/bash-complete.ts"
         ],
@@ -46,7 +54,8 @@
         "clean": true,
         "splitting": true,
         "minify": true,
-        "sourcemap": true
+        "sourcemap": true,
+        "dts": true
     },
     "dependencies": {
         "@stricli/auto-complete": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
         }
     },
     "bin": {

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -9,7 +9,7 @@ import type { LocalContext } from "./context";
 import { getNodeBinary, resolveNodeVersion } from "./node-util";
 import pLimit from "p-limit";
 
-interface CommandFlags {
+export interface FossilizeOptions {
   readonly nodeVersion: string;
   readonly platforms?: string[];
   readonly assets?: string[];
@@ -67,7 +67,7 @@ async function run(cmd: string, ...args: string[]): Promise<string> {
 
 export default async function (
   this: LocalContext,
-  flags: CommandFlags,
+  flags: FossilizeOptions,
   entrypoint: string
 ): Promise<void> {
   const entrypointStat = await fs.stat(entrypoint);

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -51,11 +51,9 @@ async function run(cmd: string, ...args: string[]): Promise<string> {
     console.error((err as ExecError).stdout);
     console.error((err as ExecError).stderr);
     const errorCode = (err as ExecError).code;
-    if (errorCode && Number.isInteger(errorCode)) {
-      process.exit((err as ExecError).code);
-    } else {
-      throw new Error("Bailing out as the command failed");
-    }
+    throw new Error(
+      `Command failed: ${cmd} ${args.join(" ")} (exit code: ${errorCode})`
+    );
   }
   if (output.stdout.trim()) {
     console.log(output.stdout);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,14 @@
+export type { FossilizeOptions } from "./impl";
+export type { SEAConfig } from "./impl";
+
+import type { FossilizeOptions } from "./impl";
+import { buildContext } from "./context";
+
+export async function fossilize(
+  options: FossilizeOptions,
+  entrypoint: string = ".",
+): Promise<void> {
+  const impl = (await import("./impl")).default;
+  const context = buildContext(process);
+  return impl.call(context, options, entrypoint);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export type { FossilizeOptions } from "./impl";
-export type { SEAConfig } from "./impl";
 
 import type { FossilizeOptions } from "./impl";
 import { buildContext } from "./context";


### PR DESCRIPTION
## Summary

Add a public API entry point so consumers can `import { fossilize } from 'fossilize'` instead of hacking around with content-hashed internal chunk files.

Closes #23

## Changes

### New: `src/index.ts` — public API wrapper
- Exports a `fossilize(options, entrypoint?)` function that constructs Stricli context internally and lazy-loads the implementation via dynamic `import()`
- Re-exports `FossilizeOptions` and `SEAConfig` types

### Modified: `src/impl.ts`
- Renamed `CommandFlags` → `FossilizeOptions` and exported the interface

### Modified: `package.json`
- Added `exports` field with `import` + `types` conditions
- Added `types` field pointing to `dist/index.d.ts`
- Updated `main` from `dist/cli.js` to `dist/index.js`
- Added `src/index.ts` to tsup entry points
- Enabled `dts: true` in tsup config for type declaration generation
- Updated `bin` paths to `dist/bin/` (tsup output structure changed with the new entry point)

## Usage

```ts
import { fossilize } from 'fossilize';

await fossilize({
  nodeVersion: 'lts',
  platforms: ['darwin-arm64', 'linux-x64', 'windows-x64'],
  outDir: './dist-bin',
  noBundle: false,
  sign: false,
  holePunch: false,
  concurrencyLimit: 3,
  cacheDir: '.node-cache',
}, './src/main.ts');
```