### PR TITLE
fix: ad-hoc sign darwin binaries when sign=false

### DIFF
--- a/src/impl.ts
+++ b/src/impl.ts
@@ -290,11 +290,43 @@ export default async function (
     }
 
     if (!flags.sign) {
-      console.log("Skipping signing, add `--sign` to sign the binary");
       if (platform.startsWith("darwin")) {
-        console.warn(
-          `macOS binaries must be signed to run. You can run \`spctl --add ${fossilizedBinary}\` to add the binary to your system's trusted binaries for testing.`
+        // Ad-hoc sign with entitlements — minimum required for Apple Silicon
+        // execution. Without at least ad-hoc signing, the kernel refuses to
+        // run the binary. Use native codesign on macOS, rcodesign elsewhere.
+        const entitlements = fileURLToPath(
+          import.meta.resolve("../entitlements.plist")
         );
+        try {
+          if (process.platform === "darwin") {
+            await run(
+              "codesign",
+              "--sign",
+              "-",
+              "--force",
+              "--entitlements",
+              entitlements,
+              fossilizedBinary
+            );
+          } else {
+            await run(
+              "rcodesign",
+              "sign",
+              "--code-signature-flags",
+              "runtime",
+              "--entitlements-xml-path",
+              entitlements,
+              fossilizedBinary
+            );
+          }
+          console.log(`Ad-hoc signed ${fossilizedBinary}`);
+        } catch {
+          console.warn(
+            `Warning: Could not ad-hoc sign ${fossilizedBinary}. ` +
+              `Install rcodesign or run on macOS for automatic signing. ` +
+              `The binary may not run on Apple Silicon without signing.`
+          );
+        }
       }
       return;
     }


### PR DESCRIPTION
## Problem

On Apple Silicon Macs, the kernel refuses to execute unsigned Mach-O binaries. When `sign=false` (the default), fossilize produced completely unsigned macOS binaries that could not run at all — the binary is killed immediately at `execve()`.

The existing workaround suggestion (`spctl --add`) requires admin privileges and is cumbersome.

## Fix

When `sign=false` and the target is `darwin-*`, apply **ad-hoc signing** with Node.js JIT entitlements as a fallback:

- **On macOS**: uses native `codesign --sign - --force --entitlements <plist>`
- **On other platforms** (Linux CI cross-compiling): uses `rcodesign sign --code-signature-flags runtime --entitlements-xml-path <plist>`
- **If neither tool is available**: warns but does not error — preserves current behavior for users without signing tools

The entitlements plist already ships with fossilize and includes the required entitlements for V8 JIT (`allow-jit`, `allow-unsigned-executable-memory`, etc.).

## Behavior change

| Scenario | Before | After |
|---|---|---|
| `sign=false`, darwin target | Unsigned binary, cannot execute on Apple Silicon | Ad-hoc signed, executable after `xattr -d com.apple.quarantine` |
| `sign=false`, linux/win target | No change | No change |
| `sign=true`, darwin target | Full rcodesign + notarization | No change |
| Cross-compiling darwin on Linux, no rcodesign installed | N/A | Warning printed, binary left unsigned (graceful fallback) |

## Notes

- Ad-hoc signing does NOT satisfy Gatekeeper for downloaded binaries — users still need to run `xattr -d com.apple.quarantine` or bypass via System Settings. For full Gatekeeper bypass, `sign=true` with a Developer ID certificate + notarization is still needed.
- The `return` at the end of the `!flags.sign` block is preserved — no change to the `sign=true` code path.